### PR TITLE
Add numbers to param "value" in SetVar function

### DIFF
--- a/definitions/grandMA3_lua_functions.lua
+++ b/definitions/grandMA3_lua_functions.lua
@@ -642,7 +642,7 @@ function AddonVars(addon_name) end
 ---@return boolean # success
 ---@param variables handle # light_userdata:variables, string:varname, value
 ---@param varname string
----@param value string
+---@param value string|number
 function SetVar(variables, varname, value) end
 
 ---@return value


### PR DESCRIPTION
SetVar can be of type string, int or double.

Arguments
Handle:
The handle of variable set.
String:
The name of the variable. It needs to be in quotation marks. Value:
The value can be a string, integer, or double.
Return
Boolean:
True / 1: The variable was set.
False / 0: The variable was not set.

Source: https://help.malighting.com/grandMA3/2.1/HTML/lua_objectfree_setvar.html